### PR TITLE
feat(cli): architecture, hooks, and changelog pages for v0.1.0

### DIFF
--- a/cli/architecture.mdx
+++ b/cli/architecture.mdx
@@ -1,0 +1,110 @@
+---
+title: CLI Architecture
+description: The Respira CLI runs every command through a deterministic six-phase execution cycle with framework-level hooks, typed tool chain functions, and structured tracing. Frozen in v0.1, extended additively in v0.2.
+---
+
+Every `respira` command runs through the same deterministic runtime: a six-phase execution cycle with framework-level hook points, typed tool chain functions, and structured JSON tracing. The cycle, the hook contracts, and the function shape are all frozen in v0.1 so v0.2 can add callback registration and extension manifests without breaking anything.
+
+## The six-phase execution cycle
+
+```
+LoadContext -> PreHooks -> Resolve -> Execute -> PostHooks -> Return
+```
+
+- **LoadContext**: gather auth, target site, switches, and task input.
+- **PreHooks**: fire the `before_resolve` framework hook.
+- **Resolve**: select and validate the Tool Chain Function that will run. Record `prerequisite_check` per declared prerequisite.
+- **Execute**: call `fn.execute(input, ctx)`. This is where the SDK call lives.
+- **PostHooks**: fire `filter_result` (payload pipeline), then `after_execute` (observation).
+- **Return**: write trace to disk if `--verbose`, assemble the result envelope, return.
+
+Phases are deterministic. Same input + same context produces the same output (modulo timing). Errors inside any phase are caught and wrapped in a `CycleError` with the original cause preserved: the cycle never re-throws at its boundary.
+
+## Framework hooks
+
+Five named hooks fire at fixed points in the cycle:
+
+- `before_resolve`: action. Fires during PreHooks.
+- `filter_plan`: filter. Fires during Resolve.
+- `before_execute`: action. Fires during Execute.
+- `filter_result`: filter. Fires during PostHooks.
+- `after_execute`: action. Record, notify, trigger follow-on work.
+
+In v0.1 no callbacks register against these hooks. The contracts are frozen. v0.2 adds **callback registration** and **extension manifests** on top, without changing anything you see in v0.1. If you are building against Respira today, nothing you write will need to change when v0.2 arrives.
+
+See [the hook framework in detail](/cli/hooks).
+
+## Tool Chain Functions
+
+Every command is a typed function with metadata:
+
+```typescript
+interface ToolChainFunction<T> {
+  name: string;                    // "read.structure"
+  description: string;
+  domainTags: readonly string[];   // ["pages", "read", "public", "anonymous"]
+  capability: "read" | "write" | "destructive";
+  prerequisites: readonly Prerequisite[];
+  internalHooks?: readonly HookDeclaration[];
+  execute(input: unknown, ctx: CycleContext): Promise<T>;
+}
+```
+
+Domain tags document what a function does across four dimensions: builder (elementor, divi, bricks, gutenberg, etc.), domain (pages, posts, media, design-system), capability (read, write, destructive), and access (public, anonymous, connected, licensed). In v0.1 these are metadata. In v0.2 they become SQL filters against the Tool Registry.
+
+## File-organization convention
+
+There are 34 public commands, and exactly 34 files under `packages/cli/src/commands/`. One `BaseCommand` subclass per file, one `ToolChainFunction` per file, always co-located. No topic-level grouping, no shared files. This is frozen.
+
+- The `ToolChainFunction` is a **named export** alongside the oclif `Command` class (which stays the default export). Name pattern: `<camelCasePath>Function`.
+- Examples: `auth/login.ts` exports `authLoginFunction`. `read/design-system.ts` exports `readDesignSystemFunction`. `write/create-page.ts` exports `writeCreatePageFunction`.
+- The function's `name` field uses dot-notation mirroring the route (`auth.login`, `read.design-system`, `write.create-page`). Traces, logs, and (v0.2) the extension manifest reader key on this.
+- v0.2 discovers every function by globbing `src/commands/**/*.ts` and picking up named exports ending in `Function`. No user file changes when the registry swaps in.
+
+## Structured tracing
+
+Pass `--verbose` on any command and the cycle writes a JSON trace to `~/.respira/traces/{invocationId}.json`. Each entry carries a phase, event type, timestamp, duration, and status. The trace is for coding agents that need to understand why something did or did not do what was expected.
+
+```bash
+$ respira read structure https://example.com --verbose
+[respira] trace: ~/.respira/traces/2adcfb73-8a97-4b94-be23-1448f2db1cce.json
+```
+
+Without `--verbose`, traces accumulate in memory and are discarded at end of command. No stderr noise.
+
+## Error handling
+
+The cycle catches phase errors and wraps them in a `CycleError` with codes like `PREREQUISITE_NOT_MET`, `VALIDATION_FAILED`, `TOOL_CHAIN_ERROR`, `PHASE_ERROR`. The original error is preserved as `cause`, so command handlers unwrap it for user display. What you see on the terminal is the familiar `RespiraError` message and hint. The `CycleError` context is logged only when `--verbose` is set.
+
+## What ships in v0.1, what ships in v0.2
+
+**In v0.1:**
+
+- The execution cycle. Six phases. Deterministic. Traceable.
+- The hook framework contracts. Five named hooks. Frozen shape.
+- Tool Chain Function abstraction for all 34 commands, co-located with each `BaseCommand` subclass.
+- Null hook registry. The hook-firing code path runs, callbacks are always empty. This is the scaffolding that makes v0.2 purely additive: `NullHookRegistry` swaps for `ManifestBackedHookRegistry`, callbacks start registering, no existing caller changes.
+- Structured tracing with `--verbose`.
+
+**In v0.2:**
+
+- Callback registration against framework-level hooks.
+- Extension manifests for third-party contributors.
+- SQLite-backed tool registry with full-text search.
+- Tool chain functions declaring internal hook points.
+- Baseline site inventory for per-site prerequisite validation.
+- Priority resolution when callbacks run in order.
+
+Every v0.2 addition is additive. No breaking changes. No "we renamed this" in the changelog. That is the whole point of landing this scaffolding now.
+
+## Why this architecture, why now
+
+The CLI works today. 34 commands, 45-tool catalog, typed SDK, green CI. Publishing as-is would be reasonable. But once extensions and third-party integrations exist, they will register callbacks against phase boundaries that do not currently exist. Retrofitting those boundaries later is breaking work. Landing them now, while nothing has subscribed to them, is cheap and costs nothing downstream.
+
+The part most users care about: none of this changes how you use the CLI. Same commands. Same flags. Same output. The architecture is there because v0.2 is going to need it, and retrofitting it later would break everyone who adopted v0.1.
+
+## Next
+
+- [The hook framework in detail](/cli/hooks)
+- [Browse commands](/cli/commands/auth)
+- [Changelog](/cli/changelog)

--- a/cli/changelog.mdx
+++ b/cli/changelog.mdx
@@ -1,0 +1,44 @@
+---
+title: CLI Changelog
+description: Release notes for Respira CLI for WordPress. Foundation release v0.1.0 shipped 2026-04-19.
+---
+
+Release notes for `@respira/cli`, `@respira/sdk`, and `@respira/cli-core`.
+
+## 0.1.0 · Foundation release · 2026-04-19
+
+First public release. The CLI ships alongside the Respira plugin and MCP server.
+
+### Architecture
+
+- Explicit six-phase execution cycle (load context, pre-hooks, resolve, execute, post-hooks, return).
+- Framework-level hook contracts in place: `before_resolve`, `filter_plan`, `before_execute`, `filter_result`, `after_execute`. Callback registration and extension manifests arrive in v0.2. The contracts are frozen and v0.1 to v0.2 is additive.
+- Every command runs through the cycle. Structured JSON trace emission available with `--verbose`, written to `~/.respira/traces/`.
+- Tool Chain Function abstraction for all 34 commands, each with capability class, domain tags, and prerequisite declarations. One command per file; the `ToolChainFunction` lives in the same file as the `BaseCommand` subclass, exported as `<camelCasePath>Function`.
+
+### Commands
+
+- 34 commands across 9 topics (auth 4, sites 5, read 8, write 7, snapshots 3, tools 3, find-element 1, exec 1, docs 1, init-claude-code 1).
+- 45-tool catalog accessible via `respira tools list/describe/search`.
+- `respira init-claude-code` generates a Claude Code skill that teaches the agent when and how to call the CLI.
+
+### Free on any public WordPress URL
+
+- `respira read structure <url>` detects 11 page builders and fetches the sitemap.
+- `respira read design-system <url>` extracts colors and fonts.
+
+### Packages
+
+- `@respira/cli` 0.1.0
+- `@respira/sdk` 0.1.0: typed TypeScript client with zod validation.
+- `@respira/cli-core` 0.1.0: execution cycle, hook contracts, tool chain function interface, trace emitter, error taxonomy, auth/sites/output utilities.
+
+### Install
+
+```bash
+npm install -g @respira/cli
+```
+
+MIT licensed. Node.js 18 or later. Works on macOS, Linux, and Windows.
+
+For commit-level history, see the [CHANGELOG.md](https://github.com/respira-press/respira-wordpress-cli/blob/main/CHANGELOG.md) in the repository.

--- a/cli/hooks.mdx
+++ b/cli/hooks.mdx
@@ -1,0 +1,82 @@
+---
+title: The hook framework
+description: Five framework-level hooks fire during every Respira CLI command. Scaffolding ships in v0.1 with a null registry. Callback registration and extension manifests arrive in v0.2. Additive, no breaking changes.
+---
+
+Five framework-level hooks fire during every `respira` command invocation. v0.1 ships the scaffolding. v0.2 ships the callback registration on top.
+
+## Status
+
+**v0.1 (now)**: the hook contracts are live and frozen. The execution cycle fires every framework hook on every command invocation. In v0.1 the hook registry is a null implementation, so no callbacks run. The code path exists, is exercised by tests, and is stable.
+
+**v0.2 (next)**: callback registration. Extension manifests. Priority resolution. If you are building something against Respira today, nothing you write will need to change when v0.2 lands.
+
+## The five framework hooks
+
+### `before_resolve`
+
+Action hook. Fires during PreHooks, before the cycle selects the Tool Chain Function. Use for observation, policy enforcement, or pre-flight validation.
+
+### `filter_plan`
+
+Filter hook. Fires during Resolve. Receives the candidate tool chain function list and returns a possibly-transformed list. Use for routing, substitution, or re-ordering.
+
+### `before_execute`
+
+Action hook. Fires during Execute, as the final gate before the Tool Chain Function runs. Use for last-chance checks, audit logging, or short-circuiting.
+
+### `filter_result`
+
+Filter hook. Fires during PostHooks. Receives the Tool Chain Function's return value and returns a possibly-transformed value. Use for redaction, enrichment, or schema validation.
+
+### `after_execute`
+
+Action hook. Fires during PostHooks, after `filter_result`. Use for record-keeping, notifications, or follow-on work that does not need to influence the return value.
+
+## Hook types
+
+- **Action**: receives payload, returns nothing, side-effects only. Used for logging, notification, policy enforcement.
+- **Filter**: receives payload, returns a transformed payload of the same shape. Used for modifying data flowing through the cycle.
+
+## Interface (stable in v0.1)
+
+```typescript
+interface HookDeclaration {
+  readonly name: string;              // e.g. "filter_page_content"
+  readonly type: "action" | "filter";
+  readonly payloadSchema?: unknown;   // zod schema in v0.2
+  readonly errorPolicy?: "abort" | "skip" | "substitute";
+}
+
+interface Callback {
+  readonly extension: string;
+  readonly priority: number;
+  readonly handler: (payload: unknown, ctx: CycleContext) => Promise<unknown | void>;
+}
+
+interface HookRegistry {
+  callbacks(hookName: string): Callback[];
+  declarations(toolChainFunctionName: string): HookDeclaration[];
+}
+```
+
+In v0.1 the runtime `HookRegistry` is a `NullHookRegistry`. Both methods return empty arrays. The ExecutionCycle iterates those empty arrays on every command, so the code path is hot, covered by tests, and ready for v0.2 to populate. This is exactly what makes v0.2 purely additive: swapping `NullHookRegistry` for `ManifestBackedHookRegistry` is a one-line change inside the cycle; nothing on the caller side needs to move.
+
+## Internal hooks on Tool Chain Functions
+
+Tool Chain Functions can declare their own hook points through the `internalHooks` array on the function metadata. These are function-specific signals, distinct from the five framework hooks. Examples of what might arrive in v0.2:
+
+- `filter_page_content` on `write.edit-page` (transform page body before persist)
+- `action_before_publish` on `write.create-post` (last check before a post goes live)
+- `filter_design_system` on `write.update-design-system` (validate or enrich color/font changes)
+
+In v0.1 the `internalHooks` field is defined and typed on the `ToolChainFunction` interface but unused. v0.2 wires it to the cycle.
+
+## Why v0.1 freezes the contracts now
+
+The goal of the v0.1 sprint is to ship the scaffolding without features so v0.2 is purely additive. Callback registration, priority resolution, extension manifests, and the real Tool Registry are all downstream changes that plug into interfaces already in place. That is the promise: if you publish code against Respira v0.1 today, your code still works with v0.2 tomorrow, unchanged.
+
+## More
+
+- [The full architecture page](/cli/architecture)
+- [Changelog](/cli/changelog)

--- a/cli/introduction.mdx
+++ b/cli/introduction.mdx
@@ -28,11 +28,17 @@ Elementor, Divi (4 and 5), Bricks, WPBakery, Beaver Builder, Oxygen, Breakdance,
 
 MIT licensed. Source at [github.com/respira-press/respira-wordpress-cli](https://github.com/respira-press/respira-wordpress-cli).
 
+## Architecture in one line
+
+Every command runs through a deterministic six-phase cycle with framework-level hook contracts and typed tool chain functions. Frozen in v0.1, extended additively in v0.2. See [architecture](/cli/architecture) and [hooks](/cli/hooks).
+
 ## Next steps
 
 - [Install the CLI](/cli/installation)
 - [Authenticate](/cli/authentication)
+- [Architecture](/cli/architecture)
 - [Claude Code integration](/cli/agents/claude-code)
+- [Changelog](/cli/changelog)
 
 ---
 

--- a/documentation.json
+++ b/documentation.json
@@ -100,6 +100,16 @@
                 "icon": "key"
               },
               {
+                "title": "Architecture",
+                "path": "cli/architecture",
+                "icon": "layers-2"
+              },
+              {
+                "title": "Hooks",
+                "path": "cli/hooks",
+                "icon": "plug"
+              },
+              {
                 "title": "respira auth",
                 "path": "cli/commands/auth",
                 "icon": "lock"
@@ -158,6 +168,11 @@
                 "title": "CLI FAQ",
                 "path": "cli/faq",
                 "icon": "help-circle"
+              },
+              {
+                "title": "CLI Changelog",
+                "path": "cli/changelog",
+                "icon": "history"
               }
             ]
           },


### PR DESCRIPTION
## Summary

Port the three new CLI doc pages from `respira.press/cli/docs` into the Documentation.AI-hosted docs repo so the two surfaces tell the same v0.1.0 story.

- `cli/architecture.mdx` — six-phase execution cycle, Tool Chain Functions, file-organization convention (34 commands = 34 files, one `BaseCommand` per file, named export `<camelCasePath>Function`, dot-notation `name` field), tracing, error handling, v0.1 vs v0.2 surface.
- `cli/hooks.mdx` — the five framework hooks, action vs filter, the frozen interface, internal hooks on Tool Chain Functions, and why v0.1 freezes the contracts (`NullHookRegistry` → `ManifestBackedHookRegistry` is a one-line swap inside the cycle; nothing on the caller side moves).
- `cli/changelog.mdx` — 0.1.0 Foundation release, shipped 2026-04-19.
- `cli/introduction.mdx` — one-line architecture summary + links to new pages.
- `documentation.json` — wire Architecture + Hooks into the CLI sidebar after Authentication, add CLI Changelog at the end of the section.

## Why

The main CLI landing, the architecture page, and the hooks page all exist at `respira.press/cli/docs/*`. This repo carried the older pages (installation, authentication, commands, agents, sdk, faq) but not the three pages added during the v0.1.0 hook-scaffolding sprint. Parity matters because Documentation.AI is the permalink surface a lot of readers hit first.

## Test plan

- [ ] Documentation.AI rebuilds and the CLI group shows Architecture, Hooks, and Changelog entries in the sidebar.
- [ ] `cli/architecture`, `cli/hooks`, `cli/changelog` render without MDX errors.
- [ ] Cross-links between the three new pages resolve.
- [ ] No regression on existing `cli/*` pages.